### PR TITLE
feat(api): add R2 music streaming endpoints

### DIFF
--- a/src/app/api/otokai/list/route.ts
+++ b/src/app/api/otokai/list/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+export const runtime = "edge";
+
+// TODO: később paraméterezni a prefixet
+const PREFIX = "music/";
+
+export async function GET() {
+  const headers = new Headers({
+    "Access-Control-Allow-Origin": "*",
+  });
+
+  try {
+    const { env } = getCloudflareContext();
+    const list = await env.hswlp_r2.list({ prefix: PREFIX, limit: 100 });
+    const items = list.objects.map((obj) => ({
+      key: obj.key,
+      size: obj.size,
+      etag: obj.etag,
+      lastModified: obj.uploaded.toISOString(),
+      contentType: obj.httpMetadata?.contentType,
+      publicUrl: `/api/otokai/stream/${encodeURIComponent(obj.key)}`,
+    }));
+    return NextResponse.json(items, { headers });
+  } catch {
+    // hiba esetén ne szivárogjon részletes adat
+    return NextResponse.json({ error: "Failed to list objects" }, { status: 500, headers });
+  }
+}

--- a/src/app/api/otokai/stream/[...key]/route.ts
+++ b/src/app/api/otokai/stream/[...key]/route.ts
@@ -1,0 +1,86 @@
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+export const runtime = "edge";
+
+const EXT_TO_TYPE: Record<string, string> = {
+  mp3: "audio/mpeg",
+  m4a: "audio/mp4",
+  flac: "audio/flac",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  // TODO: új formátumokhoz bővítsük a listát
+};
+
+function getContentType(key: string): string {
+  const ext = key.split(".").pop()?.toLowerCase() || "";
+  return EXT_TO_TYPE[ext] || "application/octet-stream";
+}
+
+function parseRange(rangeHeader: string | null) {
+  if (!rangeHeader) return null;
+  const match = rangeHeader.match(/bytes=(\d*)-(\d*)/);
+  if (!match) return null;
+  const start = match[1] ? parseInt(match[1], 10) : 0;
+  const end = match[2] ? parseInt(match[2], 10) : undefined;
+  const length = end !== undefined ? end - start + 1 : undefined;
+  return { offset: start, end, length };
+}
+
+async function handle(request: Request, params: { key: string[] }, isHead = false) {
+  const headers = new Headers({
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": "public, max-age=3600",
+  });
+
+  const key = decodeURIComponent(params.key.join("/"));
+  const { env } = getCloudflareContext();
+
+  const range = parseRange(request.headers.get("Range"));
+  headers.set("Accept-Ranges", "bytes");
+  headers.set("Content-Type", getContentType(key));
+
+  try {
+    if (isHead) {
+      const head = await env.hswlp_r2.head(key);
+      if (!head) return new Response("Not Found", { status: 404, headers });
+
+      if (range) {
+        const size = head.size;
+        let end = range.end ?? size - 1;
+        if (end >= size) end = size - 1;
+        const length = end - range.offset + 1;
+        headers.set("Content-Range", `bytes ${range.offset}-${end}/${size}`);
+        headers.set("Content-Length", String(length));
+        return new Response(null, { status: 206, headers });
+      }
+      headers.set("Content-Length", String(head.size));
+      return new Response(null, { status: 200, headers });
+    }
+
+    if (range) {
+      const obj = await env.hswlp_r2.get(key, { range: { offset: range.offset, length: range.length } });
+      if (!obj) return new Response("Not Found", { status: 404, headers });
+      const size = obj.size;
+      const r = obj.range || { offset: range.offset, length: range.length ?? size - range.offset };
+      const end = r.offset + r.length - 1;
+      headers.set("Content-Range", `bytes ${r.offset}-${end}/${size}`);
+      headers.set("Content-Length", String(r.length));
+      return new Response(obj.body, { status: 206, headers });
+    }
+
+    const obj = await env.hswlp_r2.get(key);
+    if (!obj) return new Response("Not Found", { status: 404, headers });
+    headers.set("Content-Length", String(obj.size));
+    return new Response(obj.body, { status: 200, headers });
+  } catch {
+    return new Response("Internal Server Error", { status: 500, headers });
+  }
+}
+
+export async function GET(request: Request, context: { params: { key: string[] } }) {
+  return handle(request, context.params);
+}
+
+export async function HEAD(request: Request, context: { params: { key: string[] } }) {
+  return handle(request, context.params, true);
+}


### PR DESCRIPTION
## Summary
- list R2 `music/` objects via `/api/otokai/list`
- stream R2 audio objects with byte-range support at `/api/otokai/stream/[...key]`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a40e0a5e80832581cafb78cd495a7a