### PR TITLE
feat(otokai): add basic player UI

### DIFF
--- a/src/app/otokai/page.tsx
+++ b/src/app/otokai/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import TrackList, { TrackItem } from '@/components/otokai/TrackList';
+import PlayerBar from '@/components/otokai/PlayerBar';
+
+export default function OtokaiPage() {
+  const [tracks, setTracks] = useState<TrackItem[]>([]);
+  const [error, setError] = useState(false);
+  const [currentTrack, setCurrentTrack] = useState<TrackItem | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    fetch('/api/otokai/list')
+      .then((res) => {
+        if (!res.ok) throw new Error('failed');
+        return res.json();
+      })
+      .then((data: TrackItem[]) => {
+        if (!mounted) return;
+        setTracks(data);
+        const stored = sessionStorage.getItem('otokai-current-key');
+        if (stored) {
+          const match = data.find((t) => t.key === stored);
+          if (match) setCurrentTrack(match);
+        }
+      })
+      .catch(() => setError(true));
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const handleSelect = useCallback(
+    (key: string) => {
+      const track = tracks.find((t) => t.key === key);
+      if (track) {
+        setCurrentTrack(track);
+        try {
+          sessionStorage.setItem('otokai-current-key', key);
+        } catch {
+          // ignore sessionStorage errors
+        }
+      }
+    },
+    [tracks],
+  );
+
+  const currentKey = currentTrack?.key ?? null;
+  const currentTitle = currentTrack ? currentTrack.key.split('/').pop() || currentTrack.key : '—';
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <main className="flex-1 p-4 pb-24">
+        <h1 className="mb-4 text-2xl font-bold">Otokai</h1>
+        {error && <div className="mb-4 text-sm text-red-600">Failed to load tracks.</div>}
+        <h2 className="mb-2 text-xl font-semibold">Tracks</h2>
+        <TrackList tracks={tracks} currentKey={currentKey} onSelect={handleSelect} />
+      </main>
+      <PlayerBar src={currentTrack?.publicUrl ?? null} title={currentTitle} />
+    </div>
+  );
+}

--- a/src/components/otokai/PlayerBar.tsx
+++ b/src/components/otokai/PlayerBar.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+interface PlayerBarProps {
+  src: string | null;
+  title: string;
+}
+
+export default function PlayerBar({ src, title }: PlayerBarProps) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isMuted, setIsMuted] = useState(false);
+  const [volume, setVolume] = useState(1);
+  const [duration, setDuration] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [unavailable, setUnavailable] = useState(false);
+
+  // TODO: későbbi bővítéshez extra státuszok
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const handleLoaded = () => setDuration(audio.duration);
+    const handleTime = () => setCurrentTime(audio.currentTime);
+    const handleEnded = () => setIsPlaying(false);
+    const handleError = () => {
+      setIsPlaying(false);
+      setUnavailable(true);
+    };
+
+    audio.addEventListener('loadedmetadata', handleLoaded);
+    audio.addEventListener('timeupdate', handleTime);
+    audio.addEventListener('ended', handleEnded);
+    audio.addEventListener('error', handleError);
+
+    return () => {
+      audio.removeEventListener('loadedmetadata', handleLoaded);
+      audio.removeEventListener('timeupdate', handleTime);
+      audio.removeEventListener('ended', handleEnded);
+      audio.removeEventListener('error', handleError);
+    };
+  }, []);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    setUnavailable(false);
+    setCurrentTime(0);
+    if (src) {
+      audio.src = src;
+      audio.play().then(() => setIsPlaying(true)).catch(() => setIsPlaying(false));
+    } else {
+      audio.pause();
+      audio.removeAttribute('src');
+      setIsPlaying(false);
+    }
+  }, [src]);
+
+  const togglePlay = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isPlaying) {
+      audio.pause();
+      setIsPlaying(false);
+    } else {
+      audio.play().then(() => setIsPlaying(true)).catch(() => {});
+    }
+  }, [isPlaying]);
+
+  const toggleMute = useCallback(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.muted = !audio.muted;
+    setIsMuted(audio.muted);
+  }, []);
+
+  const handleVolume = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const vol = Number(e.target.value);
+    audio.volume = vol;
+    setVolume(vol);
+  }, []);
+
+  const handleSeek = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const time = Number(e.target.value);
+    audio.currentTime = time;
+    setCurrentTime(time);
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code === 'Space') {
+        e.preventDefault();
+        togglePlay();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [togglePlay]);
+
+  const formatTime = (t: number) => {
+    const m = Math.floor(t / 60);
+    const s = Math.floor(t % 60).toString().padStart(2, '0');
+    return `${m}:${s}`;
+  };
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 border-t border-gray-200 bg-white p-2 text-sm dark:border-gray-700 dark:bg-gray-900">
+      <audio ref={audioRef} className="hidden" />
+      <div className="flex items-center gap-2 overflow-hidden">
+        <span className="flex-1 truncate">{title}</span>
+        <button onClick={togglePlay} className="px-2">{isPlaying ? 'Pause' : 'Play'}</button>
+        <button onClick={toggleMute} className="px-2">{isMuted ? 'Unmute' : 'Mute'}</button>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.01}
+          value={volume}
+          onChange={handleVolume}
+          className="w-24"
+        />
+      </div>
+      <div className="mt-1 flex items-center gap-2">
+        <input
+          type="range"
+          min={0}
+          max={duration || 0}
+          step={0.1}
+          value={currentTime}
+          onChange={handleSeek}
+          className="flex-1"
+        />
+        <span className="tabular-nums">
+          {formatTime(currentTime)} / {duration ? formatTime(duration) : '--:--'}
+        </span>
+      </div>
+      {unavailable && <div className="mt-1 text-red-600">Track unavailable.</div>}
+    </div>
+  );
+}

--- a/src/components/otokai/TrackList.tsx
+++ b/src/components/otokai/TrackList.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import React from 'react';
+
+export interface TrackItem {
+  key: string;
+  publicUrl: string;
+  // TODO: bővíthető később további meta adatokkal
+}
+
+interface TrackListProps {
+  tracks: TrackItem[];
+  currentKey: string | null;
+  onSelect: (key: string) => void;
+}
+
+export default function TrackList({ tracks, currentKey, onSelect }: TrackListProps) {
+  if (tracks.length === 0) {
+    return <div>No tracks found.</div>;
+  }
+
+  return (
+    <ul className="space-y-1 overflow-y-auto max-h-[60vh]">
+      {tracks.map((track) => {
+        const filename = track.key.split('/').pop() || track.key;
+        const selected = track.key === currentKey;
+        return (
+          <li key={track.key}>
+            <button
+              onClick={() => onSelect(track.key)}
+              className={`flex w-full items-center gap-2 rounded px-2 py-1 text-left hover:bg-gray-200 dark:hover:bg-gray-700 ${selected ? 'bg-gray-200 dark:bg-gray-700' : ''}`}
+            >
+              <span>▶︎</span>
+              <span className="truncate">{filename}</span>
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- add Otokai page that lists available tracks and loads current selection
- implement TrackList component with simple selectable listing
- add PlayerBar with play/pause, mute, volume and seek controls

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a41173a55c8325bd9f409736d8a426