### PR TITLE
feat: add dynamic track list to music landing

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import { MusicLanding } from "@/components/landing/MusicLanding";
+import { MusicLanding, type Track } from "@/components/landing/MusicLanding";
 import { SITE_NAME, SITE_DESCRIPTION } from "@/constants";
 
 export const metadata: Metadata = {
@@ -7,10 +7,35 @@ export const metadata: Metadata = {
   description: SITE_DESCRIPTION,
 };
 
+// TODO: Load tracks from backend instead of static list
+const demoTracks: Track[] = [
+  {
+    id: "1",
+    title: "Sample Track 1",
+    artist: "Artist A",
+    coverUrl: "https://picsum.photos/seed/1/200",
+    audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
+  },
+  {
+    id: "2",
+    title: "Sample Track 2",
+    artist: "Artist B",
+    coverUrl: "https://picsum.photos/seed/2/200",
+    audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3",
+  },
+  {
+    id: "3",
+    title: "Sample Track 3",
+    artist: "Artist C",
+    coverUrl: "https://picsum.photos/seed/3/200",
+    audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3",
+  },
+];
+
 export default function Home() {
   return (
     <main>
-      <MusicLanding />
+      <MusicLanding tracks={demoTracks} />
     </main>
   );
 }

--- a/src/components/landing/MusicLanding.tsx
+++ b/src/components/landing/MusicLanding.tsx
@@ -1,27 +1,76 @@
 'use client';
 
-import { useState } from "react";
+import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
 import { Play, Pause, SkipBack, SkipForward, Volume2 } from "lucide-react";
 
+export type Track = {
+  id: string;
+  title: string;
+  artist: string;
+  coverUrl: string;
+  audioUrl: string;
+};
+
+interface MusicLandingProps {
+  tracks: Track[];
+}
+
 // Egyszerű zenelejátszó placeholder
-// TODO: Integrálni valódi audio lejátszást később
-export function MusicLanding() {
+// TODO: Integrálni valódi audio lejátszást később, bővítve playlist kezeléssel
+export function MusicLanding({ tracks }: MusicLandingProps) {
   const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTrackIndex, setCurrentTrackIndex] = useState(0);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  const currentTrack = tracks[currentTrackIndex];
+  const hasPrev = currentTrackIndex > 0;
+  const hasNext = currentTrackIndex < tracks.length - 1;
+
+  const togglePlay = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (isPlaying) {
+      audio.pause();
+    } else {
+      void audio.play();
+    }
+    setIsPlaying(!isPlaying);
+  };
+
+  useEffect(() => {
+    // TODO: Sync progress bar with actual time
+    setIsPlaying(false);
+    const audio = audioRef.current;
+    if (audio) {
+      audio.pause();
+      audio.load();
+    }
+  }, [currentTrackIndex]);
 
   return (
     <div className="flex items-center justify-center min-h-screen p-4">
       <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-lg shadow p-6 flex flex-col items-center">
-        {/* TODO: Replace with real cover image */}
-        <div className="w-48 h-48 bg-gray-200 dark:bg-gray-700 rounded-md mb-4" />
+        <Image
+          src={currentTrack.coverUrl}
+          alt={currentTrack.title}
+          width={192}
+          height={192}
+          className="w-48 h-48 object-cover rounded-md mb-4"
+        />
 
         <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
-          Track Title
+          {currentTrack.title}
         </h2>
-        <p className="text-gray-600 dark:text-gray-400 mb-4">Artist</p>
+        <p className="text-gray-600 dark:text-gray-400 mb-4">
+          {currentTrack.artist}
+        </p>
 
         <div className="flex items-center gap-4 mb-4">
           <button
-            className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
+            className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50"
+            onClick={() => setCurrentTrackIndex((i) => i - 1)}
+            disabled={!hasPrev}
             aria-label="Previous track"
           >
             <SkipBack className="h-5 w-5 text-gray-700 dark:text-gray-300" />
@@ -29,14 +78,16 @@ export function MusicLanding() {
 
           <button
             className="p-4 rounded-full bg-indigo-500 hover:bg-indigo-600 text-white"
-            onClick={() => setIsPlaying(!isPlaying)}
+            onClick={togglePlay}
             aria-label={isPlaying ? "Pause" : "Play"}
           >
             {isPlaying ? <Pause className="h-6 w-6" /> : <Play className="h-6 w-6" />}
           </button>
 
           <button
-            className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
+            className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50"
+            onClick={() => setCurrentTrackIndex((i) => i + 1)}
+            disabled={!hasNext}
             aria-label="Next track"
           >
             <SkipForward className="h-5 w-5 text-gray-700 dark:text-gray-300" />
@@ -59,6 +110,9 @@ export function MusicLanding() {
           {/* TODO: Volume slider should control volume */}
           <input type="range" min="0" max="100" className="w-full" />
         </div>
+
+        {/* Rejtett audio elem a lejátszáshoz */}
+        <audio ref={audioRef} src={currentTrack.audioUrl} className="hidden" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make `MusicLanding` component accept a list of tracks and handle switching
- display track details and audio element from current selection
- demo marketing page with sample tracks

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a42fdbfe8c8325a419ca7b42525abd