### PR TITLE
feat: load R2 track list for music landing

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,41 +1,27 @@
 import { Metadata } from "next";
 import { MusicLanding, type Track } from "@/components/landing/MusicLanding";
-import { SITE_NAME, SITE_DESCRIPTION } from "@/constants";
+import { SITE_NAME, SITE_DESCRIPTION, SITE_URL } from "@/constants";
 
 export const metadata: Metadata = {
   title: SITE_NAME,
   description: SITE_DESCRIPTION,
 };
 
-// TODO: Load tracks from backend instead of static list
-const demoTracks: Track[] = [
-  {
-    id: "1",
-    title: "Sample Track 1",
-    artist: "Artist A",
-    coverUrl: "https://picsum.photos/seed/1/200",
-    audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
-  },
-  {
-    id: "2",
-    title: "Sample Track 2",
-    artist: "Artist B",
-    coverUrl: "https://picsum.photos/seed/2/200",
-    audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3",
-  },
-  {
-    id: "3",
-    title: "Sample Track 3",
-    artist: "Artist C",
-    coverUrl: "https://picsum.photos/seed/3/200",
-    audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3",
-  },
-];
+async function loadTracks(): Promise<Track[]> {
+  const res = await fetch(`${SITE_URL}/api/r2/tracks`, { cache: "no-store" });
+  if (!res.ok) {
+    // TODO: Better error handling and fallbacks
+    return [];
+  }
+  return (await res.json()) as Track[];
+}
 
-export default function Home() {
+export default async function Home() {
+  const tracks = await loadTracks();
+
   return (
     <main>
-      <MusicLanding tracks={demoTracks} />
+      <MusicLanding tracks={tracks} />
     </main>
   );
 }

--- a/src/app/api/r2/tracks/route.ts
+++ b/src/app/api/r2/tracks/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import type { Track } from "@/components/landing/MusicLanding";
+import { generateSlug } from "@/utils/slugify";
+
+// TODO: Enhance error handling and pagination if bucket grows
+function createTrack(key: string): Track {
+  const base = key.replace(/\.mp3$/i, "");
+  const [artistPart, titlePart] = base.includes(" - ") ? base.split(" - ") : [undefined, base];
+
+  return {
+    id: generateSlug(base),
+    title: titlePart.trim(),
+    artist: artistPart ? artistPart.trim() : "Unknown Artist",
+    // TODO: Később cseréljük igazi borítóra vagy saját placeholderre
+    coverUrl: "https://via.placeholder.com/300?text=Cover",
+    audioUrl: `/api/r2/track?file=${encodeURIComponent(key)}`,
+  };
+}
+
+export async function GET() {
+  const { env } = getCloudflareContext();
+  const bucket = env.hswlp_r2;
+
+  if (!bucket) {
+    return NextResponse.json({ error: "R2 bucket not configured" }, { status: 500 });
+  }
+
+  const list = await bucket.list();
+  const tracks: Track[] = list.objects
+    .filter((obj) => obj.key.toLowerCase().endsWith(".mp3"))
+    .map((obj) => createTrack(obj.key));
+
+  return NextResponse.json(tracks);
+}


### PR DESCRIPTION
## Summary
- add `/api/r2/tracks` endpoint that lists R2 mp3 files and returns Track objects
- fetch track list on the marketing page and pass to `MusicLanding`
- use remote placeholder for cover images to avoid binary assets

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a43329f07483258b510c8659536257