### PR TITLE
feat: add track metadata and favorites

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lucide-react": "^0.471.0",
     "motion": "^11.18.0",
     "ms": "^2.1.3",
+    "music-metadata": "^11.8.2",
     "next": "15.3.3",
     "next-themes": "^0.4.6",
     "nextjs-toploader": "^3.8.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
       ms:
         specifier: ^2.1.3
         version: 2.1.3
+      music-metadata:
+        specifier: ^11.8.2
+        version: 11.8.2
       next:
         specifier: 15.3.3
         version: 15.3.3(@babel/core@7.24.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -630,6 +633,9 @@ packages:
   '@babel/types@7.27.6':
     resolution: {integrity: sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==}
     engines: {node: '>=6.9.0'}
+
+  '@borewit/text-codec@0.1.1':
+    resolution: {integrity: sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==}
 
   '@cloudflare/kv-asset-handler@0.4.0':
     resolution: {integrity: sha512-+tv3z+SPp+gqTIcImN9o0hqE9xyfQjI1XD9pL6NuKjua9B1y7mNYv0S9cP+QEbA4ppVgGZEmKOvHX5G5Ei1CVA==}
@@ -3780,6 +3786,13 @@ packages:
   '@tanstack/virtual-core@3.11.3':
     resolution: {integrity: sha512-v2mrNSnMwnPJtcVqNvV0c5roGCBqeogN8jDtgtuHCphdwBasOZ17x8UV8qpHUh+u0MLfX43c0uUHKje0s+Zb0w==}
 
+  '@tokenizer/inflate@0.2.7':
+    resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tsconfig/node18@1.0.3':
     resolution: {integrity: sha512-RbwvSJQsuN9TB04AQbGULYfOGE/RnSFk/FLQ5b0NmDf5Kx2q/lABZbHQPKCO1vZ6Fiwkplu+yb9pGdLy1iGseQ==}
 
@@ -4831,9 +4844,16 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-type@21.0.0:
+    resolution: {integrity: sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==}
+    engines: {node: '>=20'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -5481,6 +5501,10 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  music-metadata@11.8.2:
+    resolution: {integrity: sha512-k7fxn9GCl27b+P+suLwMuEuS1Kft32P1jBZ/MXLh5iRTll60qbWWc/hh+Xvv70khyykcGwsVzddURzLdKymZ0g==}
+    engines: {node: '>=18'}
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -6185,6 +6209,10 @@ packages:
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
+  strtok3@10.3.4:
+    resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
+    engines: {node: '>=18'}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -6257,6 +6285,10 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  token-types@6.1.1:
+    resolution: {integrity: sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==}
+    engines: {node: '>=14.16'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -6327,6 +6359,10 @@ packages:
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
+
+  uint8array-extras@1.4.1:
+    resolution: {integrity: sha512-+NWHrac9dvilNgme+gP4YrBSumsaMZP0fNBtXXFIf33RLLKEcBUKaQZ7ULUbS0sBfcjxIZ4V96OTRkCbM7hxpw==}
+    engines: {node: '>=18'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -7710,6 +7746,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@borewit/text-codec@0.1.1': {}
 
   '@cloudflare/kv-asset-handler@0.4.0':
     dependencies:
@@ -11540,6 +11578,16 @@ snapshots:
 
   '@tanstack/virtual-core@3.11.3': {}
 
+  '@tokenizer/inflate@0.2.7':
+    dependencies:
+      debug: 4.4.1
+      fflate: 0.8.2
+      token-types: 6.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@tsconfig/node18@1.0.3': {}
 
   '@tybys/wasm-util@0.9.0':
@@ -12759,9 +12807,20 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fflate@0.8.2: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-type@21.0.0:
+    dependencies:
+      '@tokenizer/inflate': 0.2.7
+      strtok3: 10.3.4
+      token-types: 6.1.1
+      uint8array-extras: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   fill-range@7.1.1:
     dependencies:
@@ -13391,6 +13450,19 @@ snapshots:
 
   ms@2.1.3: {}
 
+  music-metadata@11.8.2:
+    dependencies:
+      '@borewit/text-codec': 0.1.1
+      '@tokenizer/token': 0.3.0
+      content-type: 1.0.5
+      debug: 4.4.1
+      file-type: 21.0.0
+      media-typer: 1.1.0
+      strtok3: 10.3.4
+      token-types: 6.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   mustache@4.2.0: {}
 
   mz@2.7.0:
@@ -13930,7 +14002,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.3.6
+      debug: 4.4.1
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -14228,6 +14300,10 @@ snapshots:
 
   strnum@1.1.2: {}
 
+  strtok3@10.3.4:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   styled-jsx@5.1.6(@babel/core@7.24.5)(react@19.1.0):
     dependencies:
       client-only: 0.0.1
@@ -14317,6 +14393,12 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  token-types@6.1.1:
+    dependencies:
+      '@borewit/text-codec': 0.1.1
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   totalist@3.0.1: {}
 
   tr46@0.0.3: {}
@@ -14400,6 +14482,8 @@ snapshots:
       - encoding
 
   ufo@1.6.1: {}
+
+  uint8array-extras@1.4.1: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/src/app/api/favorite/route.ts
+++ b/src/app/api/favorite/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { getSessionFromCookie } from "@/utils/auth";
+import { addFavorite, removeFavorite, getFavoritesByUser } from "@/db/favorites";
+
+// Lekéri a bejelentkezett felhasználó kedvenceit
+export async function GET() {
+  const session = await getSessionFromCookie();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const favorites = await getFavoritesByUser(session.user.id);
+  const ids = favorites.map((f) => f.trackId);
+  return NextResponse.json(ids);
+}
+
+// Kedvenc hozzáadása
+export async function POST(request: Request) {
+  const session = await getSessionFromCookie();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { trackId } = await request.json();
+  if (!trackId) {
+    return NextResponse.json({ error: "trackId required" }, { status: 400 });
+  }
+
+  await addFavorite(session.user.id, trackId);
+  return NextResponse.json({ success: true });
+}
+
+// Kedvenc törlése
+export async function DELETE(request: Request) {
+  const session = await getSessionFromCookie();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { trackId } = await request.json();
+  if (!trackId) {
+    return NextResponse.json({ error: "trackId required" }, { status: 400 });
+  }
+
+  await removeFavorite(session.user.id, trackId);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/r2/tracks/route.ts
+++ b/src/app/api/r2/tracks/route.ts
@@ -2,18 +2,43 @@ import { NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import type { Track } from "@/components/landing/MusicLanding";
 import { generateSlug } from "@/utils/slugify";
+import { parseBuffer } from "music-metadata";
 
 // TODO: Enhance error handling and pagination if bucket grows
-function createTrack(key: string): Track {
+async function createTrack(bucket: R2Bucket, key: string): Promise<Track> {
   const base = key.replace(/\.mp3$/i, "");
   const [artistPart, titlePart] = base.includes(" - ") ? base.split(" - ") : [undefined, base];
 
+  // Fájl beolvasása az R2-ből és metaadatok kinyerése
+  const object = await bucket.get(key);
+  let title = titlePart.trim();
+  let artist = artistPart ? artistPart.trim() : "Unknown Artist";
+  let album: string | undefined;
+  let duration: number | undefined;
+  let coverUrl = "https://via.placeholder.com/300?text=Cover";
+
+  if (object) {
+    const arrayBuffer = await object.arrayBuffer();
+    const metadata = await parseBuffer(Buffer.from(arrayBuffer), key, { duration: true });
+    title = metadata.common.title || title;
+    artist = metadata.common.artist || artist;
+    album = metadata.common.album || undefined;
+    if (metadata.format.duration) {
+      duration = Math.round(metadata.format.duration);
+    }
+    const picture = metadata.common.picture?.[0];
+    if (picture) {
+      coverUrl = `data:${picture.format};base64,${Buffer.from(picture.data).toString("base64")}`;
+    }
+  }
+
   return {
     id: generateSlug(base),
-    title: titlePart.trim(),
-    artist: artistPart ? artistPart.trim() : "Unknown Artist",
-    // TODO: Később cseréljük igazi borítóra vagy saját placeholderre
-    coverUrl: "https://via.placeholder.com/300?text=Cover",
+    title,
+    artist,
+    album,
+    duration,
+    coverUrl,
     audioUrl: `/api/r2/track?file=${encodeURIComponent(key)}`,
   };
 }
@@ -27,9 +52,10 @@ export async function GET() {
   }
 
   const list = await bucket.list();
-  const tracks: Track[] = list.objects
+  const trackPromises = list.objects
     .filter((obj) => obj.key.toLowerCase().endsWith(".mp3"))
-    .map((obj) => createTrack(obj.key));
+    .map((obj) => createTrack(bucket, obj.key));
+  const tracks = await Promise.all(trackPromises);
 
   return NextResponse.json(tracks);
 }

--- a/src/components/landing/MusicLanding.tsx
+++ b/src/components/landing/MusicLanding.tsx
@@ -2,30 +2,37 @@
 
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
-import { Play, Pause, SkipBack, SkipForward, Volume2 } from "lucide-react";
+import { Play, Pause, SkipBack, SkipForward, Volume2, Heart } from "lucide-react";
 
 export type Track = {
   id: string;
   title: string;
   artist: string;
+  album?: string;
+  duration?: number; // in seconds
   coverUrl: string;
   audioUrl: string;
 };
 
 interface MusicLandingProps {
   tracks: Track[];
+  initialFavorites?: string[]; // favorite track IDs
+  userLoggedIn?: boolean;
 }
 
-// Egyszerű zenelejátszó placeholder
-// TODO: Integrálni valódi audio lejátszást később, bővítve playlist kezeléssel
-export function MusicLanding({ tracks }: MusicLandingProps) {
+// Simple music player placeholder
+// TODO: integrate real audio playback later with playlist support
+export function MusicLanding({ tracks, initialFavorites = [], userLoggedIn }: MusicLandingProps) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentTrackIndex, setCurrentTrackIndex] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [favorites, setFavorites] = useState<Set<string>>(new Set(initialFavorites));
   const audioRef = useRef<HTMLAudioElement>(null);
 
   const currentTrack = tracks[currentTrackIndex];
   const hasPrev = currentTrackIndex > 0;
   const hasNext = currentTrackIndex < tracks.length - 1;
+  const isFavorite = favorites.has(currentTrack.id);
 
   const togglePlay = () => {
     const audio = audioRef.current;
@@ -38,6 +45,28 @@ export function MusicLanding({ tracks }: MusicLandingProps) {
     setIsPlaying(!isPlaying);
   };
 
+  // Toggle favorite state
+  const toggleFavorite = async () => {
+    if (!userLoggedIn) return;
+    const trackId = currentTrack.id;
+    const fav = favorites.has(trackId);
+    const method = fav ? "DELETE" : "POST";
+    await fetch("/api/favorite", {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ trackId }),
+    });
+    setFavorites((prev) => {
+      const next = new Set(prev);
+      if (fav) {
+        next.delete(trackId);
+      } else {
+        next.add(trackId);
+      }
+      return next;
+    });
+  };
+
   useEffect(() => {
     // TODO: Sync progress bar with actual time
     setIsPlaying(false);
@@ -46,7 +75,26 @@ export function MusicLanding({ tracks }: MusicLandingProps) {
       audio.pause();
       audio.load();
     }
+    setCurrentTime(0);
   }, [currentTrackIndex]);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    const handler = () => setCurrentTime(audio.currentTime);
+    audio.addEventListener("timeupdate", handler);
+    return () => {
+      audio.removeEventListener("timeupdate", handler);
+    };
+  }, []);
+
+  const formatTime = (sec: number) => {
+    const m = Math.floor(sec / 60);
+    const s = Math.floor(sec % 60);
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  };
+
+  const remaining = currentTrack.duration ? Math.max(0, currentTrack.duration - currentTime) : 0;
 
   return (
     <div className="flex items-center justify-center min-h-screen p-4">
@@ -59,12 +107,22 @@ export function MusicLanding({ tracks }: MusicLandingProps) {
           className="w-48 h-48 object-cover rounded-md mb-4"
         />
 
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
-          {currentTrack.title}
-        </h2>
-        <p className="text-gray-600 dark:text-gray-400 mb-4">
-          {currentTrack.artist}
-        </p>
+        <div className="flex items-center gap-2">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+            {currentTrack.title}
+          </h2>
+          {userLoggedIn && (
+            <button onClick={toggleFavorite} aria-label="Toggle favorite">
+              <Heart
+                className={`h-5 w-5 ${isFavorite ? "text-red-500 fill-red-500" : "text-gray-400"}`}
+              />
+            </button>
+          )}
+        </div>
+        <p className="text-gray-600 dark:text-gray-400">{currentTrack.artist}</p>
+        {currentTrack.album && (
+          <p className="text-gray-600 dark:text-gray-400 mb-4">{currentTrack.album}</p>
+        )}
 
         <div className="flex items-center gap-4 mb-4">
           <button
@@ -97,11 +155,15 @@ export function MusicLanding({ tracks }: MusicLandingProps) {
         <div className="w-full mb-2">
           {/* TODO: Progress bar should reflect actual track time */}
           <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
-            <span>0:00</span>
+            <span>{formatTime(currentTime)}</span>
             <div className="flex-1 h-1 bg-gray-200 dark:bg-gray-700 rounded">
-              <div className="h-1 bg-indigo-500 w-1/4"></div>
+              <div
+                className="h-1 bg-indigo-500"
+                style={{ width: currentTrack.duration ? `${(currentTime / currentTrack.duration) * 100}%` : "0%" }}
+              ></div>
             </div>
-            <span>3:45</span>
+            <span>{currentTrack.duration ? formatTime(currentTrack.duration) : "0:00"}</span>
+            <span className="ml-2">-{formatTime(remaining)}</span>
           </div>
         </div>
 
@@ -111,7 +173,7 @@ export function MusicLanding({ tracks }: MusicLandingProps) {
           <input type="range" min="0" max="100" className="w-full" />
         </div>
 
-        {/* Rejtett audio elem a lejátszáshoz */}
+        {/* Hidden audio element for playback */}
         <audio ref={audioRef} src={currentTrack.audioUrl} className="hidden" />
       </div>
     </div>

--- a/src/db/favorites.ts
+++ b/src/db/favorites.ts
@@ -1,0 +1,26 @@
+import { eq, and } from "drizzle-orm";
+import { getDB } from "./index";
+// NOTE: this uses the otokai_favourites table
+import { otokaiFavouritesTable } from "./schema";
+
+// Kedvencek lekérése felhasználó szerint
+export async function getFavoritesByUser(userId: string) {
+  const db = getDB();
+  const rows = await db.select().from(otokaiFavouritesTable).where(eq(otokaiFavouritesTable.userId, userId));
+  return rows;
+}
+
+// Kedvenc hozzáadása
+export async function addFavorite(userId: string, trackId: string) {
+  const db = getDB();
+  // Id generálása automatikusan történik a táblában
+  await db.insert(otokaiFavouritesTable).values({ userId, trackId });
+}
+
+// Kedvenc törlése
+export async function removeFavorite(userId: string, trackId: string) {
+  const db = getDB();
+  await db
+    .delete(otokaiFavouritesTable)
+    .where(and(eq(otokaiFavouritesTable.userId, userId), eq(otokaiFavouritesTable.trackId, trackId)));
+}

--- a/src/db/migrations/0011_add_otokai_favourites.sql
+++ b/src/db/migrations/0011_add_otokai_favourites.sql
@@ -1,0 +1,6 @@
+CREATE TABLE otokai_favourites (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  track_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -108,6 +108,18 @@ export const postTable = sqliteTable("post", {
   index('post_user_id_idx').on(table.userId),
 ]));
 
+// Felhasználói kedvencek táblája
+// Table storing user favorites, renamed with otokai_ prefix
+export const otokaiFavouritesTable = sqliteTable("otokai_favourites", {
+  id: text().primaryKey().$defaultFn(() => `fav_${createId()}`).notNull(),
+  userId: text().notNull().references(() => userTable.id),
+  trackId: text().notNull(),
+  createdAt: integer({ mode: "timestamp" }).$defaultFn(() => new Date()).notNull(),
+}, (table) => ([
+  index('otokai_favourites_user_id_idx').on(table.userId),
+  index('otokai_favourites_track_id_idx').on(table.trackId),
+]));
+
 // Credit transaction types
 export const CREDIT_TRANSACTION_TYPE = {
   PURCHASE: 'PURCHASE',
@@ -377,6 +389,7 @@ export const userRelations = relations(userTable, ({ many }) => ({
   purchasedItems: many(purchasedItemsTable),
   posts: many(postTable),
   teamMemberships: many(teamMembershipTable),
+  favorites: many(otokaiFavouritesTable),
 }));
 
 export const passKeyCredentialRelations = relations(passKeyCredentialTable, ({ one }) => ({
@@ -403,3 +416,4 @@ export type TeamRole = InferSelectModel<typeof teamRoleTable>;
 export type TeamInvitation = InferSelectModel<typeof teamInvitationTable>;
 export type SlowRequestLog = InferSelectModel<typeof slowRequestLogTable>;
 export type Post = InferSelectModel<typeof postTable>;
+export type OtokaiFavourite = InferSelectModel<typeof otokaiFavouritesTable>;


### PR DESCRIPTION
## Summary
- enrich track listing with ID3 metadata
- store user favorites in D1 and expose API
- show favorites and track details on landing page
- rename favorites table to otokai_favourites

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a436fe468c8325be3d7e1a90768191