### PR TITLE
Add favorites API and landing page integration

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -25,8 +25,18 @@ async function loadFavorites(): Promise<{ ids: string[]; loggedIn: boolean }> {
 }
 
 export default async function Home({ searchParams }: { searchParams: Record<string, string> }) {
-  const [tracks, favResult] = await Promise.all([loadTracks(), loadFavorites()]);
   const showFavorites = searchParams?.favorites === "1";
+  const [tracks, favResult] = await Promise.all([loadTracks(), loadFavorites()]);
+
+  if (showFavorites && !favResult.loggedIn) {
+    // User must sign in to view favorites
+    return (
+      <main>
+        <p>Please sign in to view favorites.</p>
+      </main>
+    );
+  }
+
   const filtered = showFavorites ? tracks.filter((t) => favResult.ids.includes(t.id)) : tracks;
 
   return (

--- a/src/db/migrations/0012_add_otokai_favorites.sql
+++ b/src/db/migrations/0012_add_otokai_favorites.sql
@@ -1,0 +1,6 @@
+CREATE TABLE otokai_favorites (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  track_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,8 @@
+import { getSessionFromCookie } from '@/utils/auth';
+
+// Retrieves the currently authenticated user from the session cookie
+// Returns null if no session is found
+export async function getUser() {
+  const session = await getSessionFromCookie();
+  return session?.user ?? null;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,5 @@
+import type { D1Database } from '@cloudflare/workers-types';
+
+// Export the D1 binding from the global context
+// TODO: consider more robust context handling if needed later
+export const db = (globalThis as { DB: D1Database }).DB;


### PR DESCRIPTION
## Summary
- add D1 db and auth helpers
- implement favorites API endpoints backed by D1
- wire favorite toggling and favorites-only view on landing page

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4619a74b883259185526f1c072117