### PR TITLE
fix: add Cloudflare worker types

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "zustand": "^5.0.7"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250822.0",
     "@eslint/eslintrc": "^3.3.1",
     "@next/bundle-analyzer": "^15.4.7",
     "@simplewebauthn/types": "^12.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         version: 1.3.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@opennextjs/cloudflare':
         specifier: ^1.6.5
-        version: 1.6.5(wrangler@4.31.0)
+        version: 1.6.5(wrangler@4.31.0(@cloudflare/workers-types@4.20250822.0))
       '@oslojs/encoding':
         specifier: ^1.1.0
         version: 1.1.0
@@ -93,7 +93,7 @@ importers:
         version: 4.1.0
       drizzle-orm:
         specifier: ^0.39.3
-        version: 0.39.3
+        version: 0.39.3(@cloudflare/workers-types@4.20250822.0)
       ipaddr.js:
         specifier: ^2.2.0
         version: 2.2.0
@@ -164,6 +164,9 @@ importers:
         specifier: ^5.0.7
         version: 5.0.7(@types/react@19.1.10)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20250822.0
+        version: 4.20250822.0
       '@eslint/eslintrc':
         specifier: ^3.3.1
         version: 3.3.1
@@ -211,7 +214,7 @@ importers:
         version: 5.9.2
       wrangler:
         specifier: ^4.31.0
-        version: 4.31.0
+        version: 4.31.0(@cloudflare/workers-types@4.20250822.0)
 
 packages:
 
@@ -686,6 +689,9 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workers-types@4.20250822.0':
+    resolution: {integrity: sha512-SR5nxiclSEXS/lVwcfFCS/h7L99VWg0wa2B2CavdTAOwGznwTNcd3vmrrer3LwkqhAUQnDc2aZg3HbRvoh4LYw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -7890,6 +7896,8 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250816.0':
     optional: true
 
+  '@cloudflare/workers-types@4.20250822.0': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -9707,7 +9715,7 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@opennextjs/cloudflare@1.6.5(wrangler@4.31.0)':
+  '@opennextjs/cloudflare@1.6.5(wrangler@4.31.0(@cloudflare/workers-types@4.20250822.0))':
     dependencies:
       '@dotenvx/dotenvx': 1.31.0
       '@opennextjs/aws': 3.7.4(patch_hash=8e4cd762915fd42682cca71c7b58c9b29621f64162bd73c72d7b98ec1fd96ebb)
@@ -9715,7 +9723,7 @@ snapshots:
       enquirer: 2.4.1
       glob: 11.0.3
       ts-tqdm: 0.8.6
-      wrangler: 4.31.0
+      wrangler: 4.31.0(@cloudflare/workers-types@4.20250822.0)
       yargs: 18.0.0
     transitivePeerDependencies:
       - aws-crt
@@ -12395,7 +12403,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.39.3: {}
+  drizzle-orm@0.39.3(@cloudflare/workers-types@4.20250822.0):
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20250822.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -14863,7 +14873,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20250816.0
       '@cloudflare/workerd-windows-64': 1.20250816.0
 
-  wrangler@4.31.0:
+  wrangler@4.31.0(@cloudflare/workers-types@4.20250822.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@cloudflare/unenv-preset': 2.6.2(unenv@2.0.0-rc.19)(workerd@1.20250816.0)
@@ -14874,6 +14884,7 @@ snapshots:
       unenv: 2.0.0-rc.19
       workerd: 1.20250816.0
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20250822.0
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,4 @@
-import type { D1Database } from '@cloudflare/workers-types';
+import type { D1Database } from '@cloudflare/workers-types'; // relies on Cloudflare worker types
 
 // Export the D1 binding from the global context
 // TODO: consider more robust context handling if needed later


### PR DESCRIPTION
## Summary
- add `@cloudflare/workers-types` dev dependency for D1 types
- document reliance on workers types in db helper

## Testing
- `pnpm lint`
- `pnpm build` *(fails: `Uint8Array<ArrayBufferLike>` not assignable to `BufferSource` in `src/utils/password-hasher.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68a8070016308325b04a525ab8cf838c