### PR TITLE
fix: validate passkey response

### DIFF
--- a/src/app/(auth)/sign-up/passkey-sign-up.actions.ts
+++ b/src/app/(auth)/sign-up/passkey-sign-up.actions.ts
@@ -129,9 +129,16 @@ export const startPasskeyRegistrationAction = createServerAction()
   });
 
 const completePasskeyRegistrationSchema = z.object({
-  response: z.custom<RegistrationResponseJSON>((val): val is RegistrationResponseJSON => {
-    return typeof val === "object" && val !== null && "id" in val && "rawId" in val;
-  }, "Invalid registration response"),
+  // Ensure the WebAuthn response includes an `id` to prevent runtime errors
+  // TODO: validate additional fields like response type
+  response: z.custom<RegistrationResponseJSON>(
+    (val): val is RegistrationResponseJSON =>
+      typeof val === "object" &&
+      val !== null &&
+      typeof (val as { id?: unknown }).id === "string" &&
+      typeof (val as { rawId?: unknown }).rawId === "string",
+    "Invalid registration response"
+  ),
 });
 
 export const completePasskeyRegistrationAction = createServerAction()

--- a/src/app/(settings)/settings/security/passkey-settings.actions.ts
+++ b/src/app/(settings)/settings/security/passkey-settings.actions.ts
@@ -71,9 +71,17 @@ export const generateRegistrationOptionsAction = createServerAction()
     }, RATE_LIMITS.SETTINGS);
   });
 
+// Validáció a response objektumra, hogy legyen `id` mező
+// TODO: később bővíteni további mezők ellenőrzésével
 const verifyRegistrationSchema = z.object({
   email: z.string().email(),
-  response: z.custom<RegistrationResponseJSON>(),
+  response: z.custom<RegistrationResponseJSON>(
+    (val): val is RegistrationResponseJSON =>
+      typeof val === "object" &&
+      val !== null &&
+      typeof (val as { id?: unknown }).id === "string",
+    "Invalid registration response"
+  ),
   challenge: z.string(),
 });
 
@@ -189,9 +197,16 @@ export const generateAuthenticationOptionsAction = createServerAction()
   });
 
 const verifyAuthenticationSchema = z.object({
-  response: z.custom<AuthenticationResponseJSON>((val): val is AuthenticationResponseJSON => {
-    return typeof val === "object" && val !== null && "id" in val && "rawId" in val;
-  }, "Invalid authentication response"),
+  // Ensure the client response contains an `id` to avoid runtime errors
+  // TODO: expand validation for other required fields
+  response: z.custom<AuthenticationResponseJSON>(
+    (val): val is AuthenticationResponseJSON =>
+      typeof val === "object" &&
+      val !== null &&
+      typeof (val as { id?: unknown }).id === "string" &&
+      typeof (val as { rawId?: unknown }).rawId === "string",
+    "Invalid authentication response"
+  ),
   challenge: z.string(),
 });
 

--- a/src/app/api/webauthn/authenticate/route.ts
+++ b/src/app/api/webauthn/authenticate/route.ts
@@ -15,7 +15,15 @@ interface AuthRequest {
 }
 
 export async function POST(request: Request) {
-  const { response, challenge } = (await request.json()) as AuthRequest
+  const body = (await request.json()) as AuthRequest
+
+  // Ellenőrizzük, hogy a kliens küldte-e az `id` mezőt
+  // TODO: további mezők validálása a jövőben
+  if (typeof body.response !== 'object' || body.response === null || typeof body.response.id !== 'string') {
+    return NextResponse.json({ success: false }, { status: 400 })
+  }
+
+  const { response, challenge } = body
 
   const { verifyAuthenticationResponse } = await import('@simplewebauthn/server')
 

--- a/src/app/api/webauthn/register/route.ts
+++ b/src/app/api/webauthn/register/route.ts
@@ -24,6 +24,12 @@ export async function POST(request: Request) {
   }
   const body = (await request.json()) as VerifyRequest
 
+  // Ellenőrzés: a választ tartalmaznia kell `id`-t, különben a későbbi feldolgozás hibát okoz
+  // TODO: szükség esetén bővítsük további mezők validációjával
+  if (typeof body.response !== 'object' || body.response === null || typeof body.response.id !== 'string') {
+    return NextResponse.json({ success: false }, { status: 400 })
+  }
+
   const { verifyRegistrationResponse } = await import('@simplewebauthn/server')
   const { UAParser } = await import('ua-parser-js')
 


### PR DESCRIPTION
## Summary
- ellenőrzöm, hogy a WebAuthn válasz `id` mezője ténylegesen string legyen, így elkerülhető a TypeError

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a8147d35488325881a0b0c58ab5b57